### PR TITLE
Diva pom improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,26 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <!--
+                In windup-graph-impl artifact, the janusgraph-berkeleyje dependency defines the 'oracleReleases' repository in order to retrieve
+                artifact com.sleepycat:je:7.4.5 from Oracle Maven repo (http://download.oracle.com/maven/com/sleepycat/je/7.4.5/je-7.4.5.pom)
+                BUT Maven 3.8.1 "Block external HTTP repositories by default" (https://issues.apache.org/jira/browse/MNG-7118) so
+                here the HTTP*S* version of Oracle Maven repo is defined.
+            -->
+            <id>oracleReleases-mirror</id>
+            <name>oracleReleases-mirror</name>
+            <url>https://download.oracle.com/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <modules>
         <module>bom</module>
         <module>windup-test-harness</module>

--- a/rules-java-diva/addon/pom.xml
+++ b/rules-java-diva/addon/pom.xml
@@ -24,52 +24,9 @@
         <dependency>
             <groupId>com.github.konveyor.tackle-diva</groupId>
             <artifactId>diva-core</artifactId>
-            <version>0.1.1</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.wala</groupId>
-            <artifactId>com.ibm.wala.util</artifactId>
-            <version>1.5.7</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.wala</groupId>
-            <artifactId>com.ibm.wala.core</artifactId>
-            <version>1.5.7</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.wala</groupId>
-            <artifactId>com.ibm.wala.cast</artifactId>
-            <version>1.5.7</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.wala</groupId>
-            <artifactId>com.ibm.wala.cast.java</artifactId>
-            <version>1.5.7</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.wala</groupId>
-            <artifactId>com.ibm.wala.cast.java.ecj</artifactId>
-            <version>1.5.7</version>
-            <optional>true</optional>
+            <version>0.1.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
-            <optional>true</optional>
-        </dependency>
         <!-- Addon Dependencies -->
 
         <dependency>


### PR DESCRIPTION
This PR relies on https://github.com/konveyor/tackle-diva/pull/41 being merged and the `0.1.2` version of `diva-core` being available.