### PR TITLE
Diva's PR pom.xml improvements for tests

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -207,6 +207,12 @@
                 <classifier>forge-addon</classifier>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.windup.rules.apps</groupId>
+                <artifactId>windup-rules-java-diva</artifactId>
+                <classifier>forge-addon</classifier>
+                <version>${project.version}</version>
+            </dependency>
 
 
             <!-- Windup Rules Base -->

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <version.forge>3.9.2.Final</version.forge>
         <version.furnace>2.28.4.Final</version.furnace>
-        <version.nexus.index>21.07.18.Final</version.nexus.index>
+        <version.nexus.index>21.11.30.Final</version.nexus.index>
     </properties>
 
     <!-- Does NOT use windup-parent - this is a BOM. -->

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -39,6 +39,11 @@
             <classifier>forge-addon</classifier>
         </dependency>
         <dependency>
+            <groupId>org.jboss.windup.rules.apps</groupId>
+            <artifactId>windup-rules-java-diva</artifactId>
+            <classifier>forge-addon</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.windup.graph</groupId>
             <artifactId>windup-graph-api</artifactId>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rules-java-diva/tests/pom.xml
+++ b/rules-java-diva/tests/pom.xml
@@ -21,7 +21,6 @@
             <groupId>org.jboss.windup.rules.apps</groupId>
             <artifactId>windup-rules-java-diva</artifactId>
             <classifier>forge-addon</classifier>
-            <version>5.2.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rules-java-diva/tests/src/test/java/org/jboss/windup/rules/apps/diva/DivaTest.java
+++ b/rules-java-diva/tests/src/test/java/org/jboss/windup/rules/apps/diva/DivaTest.java
@@ -14,6 +14,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.exec.WindupProcessor;
@@ -21,22 +22,28 @@ import org.jboss.windup.exec.configuration.WindupConfiguration;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.rules.apps.diva.model.DivaAppModel;
+import org.jboss.windup.rules.apps.diva.model.DivaOpModel;
+import org.jboss.windup.rules.apps.diva.model.DivaTxModel;
 import org.jboss.windup.rules.apps.java.config.SourceModeOption;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.locationtech.jts.util.Assert;
 
-import org.jboss.windup.rules.apps.diva.model.DivaAppModel;
-import org.jboss.windup.rules.apps.diva.model.DivaOpModel;
-import org.jboss.windup.rules.apps.diva.model.DivaTxModel;
-
 @RunWith(Arquillian.class)
 public class DivaTest {
 
     @Deployment
-    @AddonDependencies
+    @AddonDependencies({
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java-diva"),
+            @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+            @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+            @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
     public static AddonArchive getDeployment() {
-        return ShrinkWrap.create(AddonArchive.class).addClass(DivaTest.class).addBeansXML();
+        return ShrinkWrap.create(AddonArchive.class).addBeansXML();
     }
 
     @Inject

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/JavaClass.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/JavaClass.java
@@ -387,6 +387,15 @@ public class JavaClass extends ParameterizedGraphCondition implements JavaClassB
             result.addAll(typeFilterPattern.getRequiredParameterNames());
         if (lineMatchPattern != null)
             result.addAll(lineMatchPattern.getRequiredParameterNames());
+        if (annotationCondition != null)
+            result.addAll(annotationCondition.getRequiredParameterNames());
+        if (additionalAnnotationConditions != null && !additionalAnnotationConditions.isEmpty())
+        {
+            for (AnnotationCondition condition : additionalAnnotationConditions)
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
         return result;
     }
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationCondition.java
@@ -6,6 +6,8 @@ import org.jboss.windup.config.condition.EvaluationStrategy;
 import org.jboss.windup.rules.apps.java.scan.ast.annotations.JavaAnnotationTypeValueModel;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
+import java.util.Set;
+
 /**
  * {@link AnnotationCondition} provides support for filtering type references based upon detailed annotation information.
  *
@@ -21,4 +23,10 @@ public abstract class AnnotationCondition
      * false otherwise.
      */
     public abstract boolean evaluate(GraphRewrite event, EvaluationContext context, EvaluationStrategy strategy, JavaAnnotationTypeValueModel value);
+
+    /**
+     * Called by the framework to obtain the list of parameters required by the condition.
+     * @return The parameter names used in the condition.
+     */
+    public abstract Set<String> getRequiredParameterNames();
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationListCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationListCondition.java
@@ -1,7 +1,9 @@
 package org.jboss.windup.rules.apps.java.condition.annotation;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.condition.EvaluationStrategy;
@@ -135,5 +137,19 @@ public class AnnotationListCondition extends AnnotationCondition
             }
         }
         return selectedValues;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (conditions != null) {
+            for (AnnotationCondition condition : conditions)
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
+
+        return result;
     }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationLiteralCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationLiteralCondition.java
@@ -8,6 +8,9 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.param.ParameterizedPatternResult;
 import org.ocpsoft.rewrite.param.RegexParameterizedPatternParser;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Matches a literal value on an annotation element. The value itself is a pattern match and the value is always treated as
  * a string.
@@ -61,5 +64,16 @@ public class AnnotationLiteralCondition extends AnnotationCondition
         }
 
         return true;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (pattern != null) {
+            result.addAll(pattern.getRequiredParameterNames());
+        }
+
+        return result;
     }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
@@ -1,7 +1,9 @@
 package org.jboss.windup.rules.apps.java.condition.annotation;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.condition.EvaluationStrategy;
@@ -85,5 +87,22 @@ public class AnnotationTypeCondition extends AnnotationCondition
                 return false;
         }
         return true;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (pattern != null) {
+            result.addAll(pattern.getRequiredParameterNames());
+        }
+        if (conditions != null) {
+            for (AnnotationCondition condition : conditions.values())
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
+
+        return result;
     }
 }

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleAnnotatedClass.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleAnnotatedClass.java
@@ -1,0 +1,13 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+@SimpleTestAnnotation(value1 = "value 1", value2 = "value 2")
+@SimpleTestAnnotation(value1 = "value 3", value2 = "value 4")
+@SimpleSingleMemberAnnotation(SimpleAnnotatedClass.SINGLE_MEMBER_VALUE)
+public class SimpleAnnotatedClass
+{
+    public static final String SINGLE_MEMBER_VALUE = "single member value";
+
+    @SimpleTestAnnotation(value1 = "member value 1", value2 = "member value 2")
+    private String testString = "test";
+
+}

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleSingleMemberAnnotation.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleSingleMemberAnnotation.java
@@ -1,0 +1,6 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+public @interface SimpleSingleMemberAnnotation
+{
+    String value();
+}

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleTestAnnotation.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleTestAnnotation.java
@@ -1,0 +1,12 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+public @interface SimpleTestAnnotation
+{
+    String value1();
+
+    String value2();
+}


### PR DESCRIPTION
In this PR there are:

- removed `<version>5.2.1-SNAPSHOT</version>` from `rules-java-diva/tests/pom.xml` file which is mandatory for safely manage releases without having to manage the change of this version value during releases (supported by changes in bom file)
- deployed forge addons in test consistently with other windup's tests
- merged latest changes from `master` branch
