### PR TITLE
Added binary mode test with hibernate-tutorial-web-3.3.2.GA.war

### DIFF
--- a/rules-java-diva/tests/src/test/java/org/jboss/windup/rules/apps/diva/DivaTest.java
+++ b/rules-java-diva/tests/src/test/java/org/jboss/windup/rules/apps/diva/DivaTest.java
@@ -100,5 +100,21 @@ public class DivaTest {
         }
     }
 
+    @Test
+    public void testHibernateTutorialWeb() throws IOException {
+        try (GraphContext context = factory.create(true)) {
+            Path inputPath = Paths.get("../../test-files/hibernate-tutorial-web-3.3.2.GA.war");
+            Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "Windup")
+                    .resolve(UUID.randomUUID().toString());
+
+            WindupConfiguration windupConfiguration = new WindupConfiguration()
+                    .setGraphContext(context)
+                    .setOptionValue(EnableTransactionAnalysisOption.NAME, true)
+                    .addInputPath(inputPath)
+                    .setOutputDirectory(outputPath);
+            processor.execute(windupConfiguration);
+        }
+    }
+
 
 }


### PR DESCRIPTION
Shared the test mentioned in https://github.com/windup/windup/pull/1427#pullrequestreview-931559555 that throws the exception
```java
Caused by: java.lang.NullPointerException
	at io.tackle.diva.Framework.getFilteredTargets(Framework.java:655)
	at io.tackle.diva.Framework.traverse(Framework.java:597)
	at io.tackle.diva.Framework.traverse(Framework.java:538)
	at org.jboss.windup.rules.apps.diva.analysis.DivaLauncher.launch(DivaLauncher.java:326)
	... 119 more
```