### PR TITLE
Diva line mapping

### DIFF
--- a/decompiler/api/src/main/java/org/jboss/windup/decompiler/api/DecompilationListener.java
+++ b/decompiler/api/src/main/java/org/jboss/windup/decompiler/api/DecompilationListener.java
@@ -13,6 +13,13 @@ public interface DecompilationListener
     void fileDecompiled(List<String> sourceClassPaths, String outputPath);
 
     /**
+     * Indicates that the files at inputPath has been decompiled to outputPath
+     */
+    default void fileDecompiled(List<String> sourceClassPaths, String outputPath, int[] lineMapping) {
+        fileDecompiled(sourceClassPaths, outputPath);
+    }
+
+    /**
      * Called to indicate that decompilation of this particular files has failed for the specified reason.
      */
     void decompilationFailed(List<String> sourceClassPaths, String message);

--- a/decompiler/impl-fernflower/src/main/java/org/jboss/windup/decompiler/fernflower/FernFlowerResultSaver.java
+++ b/decompiler/impl-fernflower/src/main/java/org/jboss/windup/decompiler/fernflower/FernFlowerResultSaver.java
@@ -55,10 +55,16 @@ public class FernFlowerResultSaver implements IResultSaver
             {
                 fw.write(content);
             }
-            if (listener != null)
-                listener.fileDecompiled(sourceClassFiles, outputFile.toString());
+            if (listener != null) {
+                if (mapping != null) {
+                    listener.fileDecompiled(sourceClassFiles, outputFile.toString(), mapping);
+                } else {
+                    listener.fileDecompiled(sourceClassFiles, outputFile.toString());
+                }
+            }
 
             fileSaved = true;
+
         }
         catch (IOException t)
         {

--- a/decompiler/impl-fernflower/src/main/java/org/jboss/windup/decompiler/fernflower/FernflowerDecompiler.java
+++ b/decompiler/impl-fernflower/src/main/java/org/jboss/windup/decompiler/fernflower/FernflowerDecompiler.java
@@ -50,6 +50,7 @@ public class FernflowerDecompiler extends AbstractDecompiler
         Map<String, Object> options = new HashMap<>();
         options.put(IFernflowerPreferences.MAX_PROCESSING_METHOD, 30);
         options.put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
+        options.put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
         return options;
     }
 
@@ -95,6 +96,7 @@ public class FernflowerDecompiler extends AbstractDecompiler
 
                     ClassDecompileRequest firstRequest = requests.get(0);
                     List<String> classFiles = pathsFromDecompilationRequests(requests);
+
                     FernFlowerResultSaver resultSaver = getResultSaver(
                                 pathsFromDecompilationRequests(requests), firstRequest.getOutputDirectory().toFile(),
                                 listener);

--- a/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaLauncher.java
+++ b/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaLauncher.java
@@ -254,16 +254,20 @@ public class DivaLauncher extends GraphOperation {
                     if (rootFileModel instanceof WarArchiveModel) {
                         Path classRoot = unzippedPath.resolve("WEB-INF").resolve("classes");
                         if (classRoot.toFile().isDirectory()) {
-                            scope.addToScope(JavaSourceAnalysisScope.SOURCE,
-                                    new SourceDirectoryTreeModule(classRoot.toFile()));
+                            //scope.addToScope(JavaSourceAnalysisScope.SOURCE,
+                            //        new SourceDirectoryTreeModule(classRoot.toFile()));
+                            scope.addToScope(ClassLoaderReference.Application,
+                                    new BinaryDirectoryTreeModule(classRoot.toFile()));
                         }
 
                     } else if (rootFileModel instanceof JarArchiveModel
                             && Util.any(projects, p2 -> p2.getRootFileModel().asFile().getAbsolutePath()
                                     .startsWith(unzippedPath.normalize().toString()))) {
 
-                        scope.addToScope(JavaSourceAnalysisScope.SOURCE,
-                                new SourceDirectoryTreeModule(unzippedPath.toFile()));
+                        //scope.addToScope(JavaSourceAnalysisScope.SOURCE,
+                        //        new SourceDirectoryTreeModule(unzippedPath.toFile()));
+                        scope.addToScope(ClassLoaderReference.Application,
+                                new BinaryDirectoryTreeModule(unzippedPath.toFile()));
 
                     } else if (rootFileModel instanceof JarArchiveModel) {
                         stdList.add(rootFileModel.getFilePath());

--- a/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaToWindup.java
+++ b/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaToWindup.java
@@ -1,11 +1,11 @@
 package org.jboss.windup.rules.apps.diva.analysis;
 
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.WindupVertexFrame;
-import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.rules.apps.diva.model.DivaConstraintModel;
 import org.jboss.windup.rules.apps.diva.model.DivaContextModel;
@@ -16,10 +16,13 @@ import org.jboss.windup.rules.apps.diva.model.DivaSqlOpModel;
 import org.jboss.windup.rules.apps.diva.model.DivaStackTraceModel;
 import org.jboss.windup.rules.apps.diva.model.DivaTxModel;
 import org.jboss.windup.rules.apps.diva.service.DivaStackTraceService;
+import org.jboss.windup.rules.apps.java.model.AbstractJavaSourceModel;
 import org.jboss.windup.rules.apps.java.model.JavaClassModel;
 import org.jboss.windup.rules.apps.java.model.JavaMethodModel;
+import org.jboss.windup.rules.apps.java.model.LineMappingModel;
 import org.jboss.windup.rules.apps.java.service.JavaClassService;
 import org.jboss.windup.rules.apps.java.service.JavaMethodService;
+import org.jboss.windup.rules.apps.java.service.LineMappingService;
 
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.IMethod.SourcePosition;
@@ -151,6 +154,7 @@ public class DivaToWindup<T extends WindupVertexFrame> implements Report {
                 DivaStackTraceService service = new DivaStackTraceService(gc);
                 JavaClassService classService = new JavaClassService(gc);
                 JavaMethodService methodService = new JavaMethodService(gc);
+                LineMappingService lineMappingService = new LineMappingService(gc);
                 DivaStackTraceModel parent = null;
                 DivaStackTraceModel current = null;
                 for (Trace t : ((Trace) data).reversed()) {
@@ -167,13 +171,26 @@ public class DivaToWindup<T extends WindupVertexFrame> implements Report {
                         JavaMethodModel methodModel = methodService.createJavaMethod(classModel,
                                 m.getName().toString());
 
-                        FileModel sourceFile = classModel.getOriginalSource();
+                        AbstractJavaSourceModel sourceFile = classModel.getOriginalSource();
+                        LineMappingModel lineMapping = null;
                         if (sourceFile == null) {
                             sourceFile = classModel.getDecompiledSource();
+                            lineMapping = sourceFile.getLineMapping();
                         }
-                        current = service.getOrCreate(sourceFile, p.getFirstLine(), p.getFirstCol(),
-                                p.getLastOffset() - p.getFirstOffset(), parent, methodModel);
-                        parent = current;
+
+                        if (lineMapping != null) {
+                            Map<Integer, Integer> mapping = lineMappingService.getMapping(lineMapping);
+                            int lineNum = mapping.getOrDefault(p.getFirstLine(), p.getFirstLine());
+                            current = service.getOrCreate(sourceFile, lineNum, 0, 0, parent, methodModel);
+                            parent = current;
+
+                        } else if (sourceFile != null) {
+                            current = service.getOrCreate(sourceFile, p.getFirstLine(), p.getFirstCol(),
+                                    p.getLastOffset() - p.getFirstOffset(), parent, methodModel);
+                            parent = current;
+
+                        }
+
                     }
                 }
                 ((DivaOpModel) model).setStackTrace(current);

--- a/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaToWindup.java
+++ b/rules-java-diva/addon/src/main/java/org/jboss/windup/rules/apps/diva/analysis/DivaToWindup.java
@@ -175,7 +175,8 @@ public class DivaToWindup<T extends WindupVertexFrame> implements Report {
                         LineMappingModel lineMapping = null;
                         if (sourceFile == null) {
                             sourceFile = classModel.getDecompiledSource();
-                            lineMapping = sourceFile.getLineMapping();
+                            if (sourceFile != null)
+                                lineMapping = sourceFile.getLineMapping();
                         }
 
                         if (lineMapping != null) {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/AbstractJavaSourceModel.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/AbstractJavaSourceModel.java
@@ -31,6 +31,7 @@ public interface AbstractJavaSourceModel extends FileModel, SourceFileModel
     String PACKAGE_NAME = "packageName";
     String JAVA_CLASS_MODEL = "javaClass";
     String ROOT_SOURCE_FOLDER = "rootSourceFolder";
+    String LINE_MAPPING = "lineMapping";
 
     /**
      * This is the "root" directory for this source file.
@@ -93,4 +94,17 @@ public interface AbstractJavaSourceModel extends FileModel, SourceFileModel
      */
     @Adjacency(label = FileReferenceModel.FILE_MODEL, direction = Direction.IN)
     List<WindupVertexFrame> getAllTypeReferencesInternal();
+
+    /**
+     * Line mapping between original and decompiled source code
+     */
+    @Adjacency(label = LINE_MAPPING, direction = Direction.OUT)
+    LineMappingModel getLineMapping();
+
+    /**
+     * Line mapping between original and decompiled source code
+     */
+    @Adjacency(label = LINE_MAPPING, direction = Direction.OUT)
+    void setLineMapping(LineMappingModel model);
+
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/LineMappingModel.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/LineMappingModel.java
@@ -1,0 +1,25 @@
+package org.jboss.windup.rules.apps.java.model;
+
+import org.jboss.windup.graph.Property;
+import org.jboss.windup.graph.model.TypeValue;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+
+
+@TypeValue(LineMappingModel.TYPE)
+public interface LineMappingModel extends WindupVertexFrame {
+        String TYPE = "LineMappingModel";
+        String ENCODED_MAPPING = "encodedMapping";
+
+        /**
+         * Indicates whether the class is declared "public".
+         */
+        @Property(ENCODED_MAPPING)
+        String getEncodedMapping();
+
+        /**
+         * Indicates whether the class is declared "public".
+         */
+        @Property(ENCODED_MAPPING)
+        void setEncodedMapping(String s);
+
+}

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/LineMappingService.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/LineMappingService.java
@@ -1,0 +1,64 @@
+package org.jboss.windup.rules.apps.java.service;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.forge.roaster._shade.org.eclipse.core.internal.preferences.Base64;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.rules.apps.java.model.LineMappingModel;
+
+public class LineMappingService extends GraphService<LineMappingModel> {
+
+    public LineMappingService(GraphContext context) {
+        super(context, LineMappingModel.class);
+    }
+
+    static final ThreadLocal<Map<Integer, Integer>[]> cache = new ThreadLocal<>();
+    static final ThreadLocal<Object[]> ids = new ThreadLocal<>();
+    static final int cacheSize = 256; // no need to be large
+
+    public LineMappingModel create(int[] data) {
+        LineMappingModel model = create();
+        if (data != null) {
+            ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * 4);
+            byteBuffer.asIntBuffer().put(data);
+            String encodedData = new String(Base64.encode(byteBuffer.array()));
+            model.setEncodedMapping(encodedData);
+        }
+        return model;
+    }
+
+    public Map<Integer, Integer> getMapping(LineMappingModel model) {
+
+        if (cache.get() == null) {
+            cache.set(new Map[cacheSize]);
+            ids.set(new Object[cacheSize]);
+        }
+        Map<Integer, Integer>[] localCache = cache.get();
+        Object[] localIds = ids.get();
+
+        int index = (model.getId().hashCode() & Integer.MAX_VALUE) % localCache.length;
+        if (model.getId().equals(localIds[index])) {
+            return localCache[index];
+        }
+
+        Map<Integer, Integer> lineMapping = new HashMap<>();
+
+        String encoded = model.getEncodedMapping();
+        if (encoded != null && !encoded.isEmpty()) { 
+            byte[] bytes = Base64.decode(encoded.getBytes());
+            IntBuffer data = ByteBuffer.wrap(bytes).asIntBuffer();
+            while (data.hasRemaining()) {
+                lineMapping.put(data.get(), data.get());
+            }
+        }
+
+        localIds[index] = model.getId();
+        localCache[index] = lineMapping;
+
+        return lineMapping;
+    }
+}

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/LineMappingServiceTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/LineMappingServiceTest.java
@@ -1,0 +1,52 @@
+package org.jboss.windup.rules.apps.java.service;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.rules.apps.java.model.LineMappingModel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class LineMappingServiceTest {
+
+    @AddonDependencies({ @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+            @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+            @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-base"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi") })
+    public static AddonArchive getDeployment() {
+        return ShrinkWrap.create(AddonArchive.class).addBeansXML();
+    }
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testLineMappingService() throws Exception {
+        final Path folder = OperatingSystemUtils.createTempDir().toPath();
+        try (final GraphContext context = factory.create(folder, true)) {
+
+            LineMappingService service = new LineMappingService(context);
+
+            LineMappingModel model = service.create(new int[] { 1, 2, 3, 4 });
+
+            Map<Integer, Integer> map = service.getMapping(model);
+
+            Assert.assertEquals(2, (int) map.get(1));
+            Assert.assertEquals(4, (int) map.get(3));
+        }
+    }
+}


### PR DESCRIPTION
- This code adds a functionality to decompiler and rule-java modules, to remember **line mapping information**, computed by fernflower decompiler for each decompiled file.   See the attached code snippet. 
- The line mapping information relates the line numbers in original source java files (= information kept in the compiled bytecode), to those in the decompiled sources.  
- This information is useful for diva reporting phase, to present the result of binary analysis on decompiled source reports.
https://github.com/akihikot/windup/blob/2a0d306630944d6292fcee9e3024d7a7ab7ff803/decompiler/impl-fernflower/src/main/java/org/jboss/windup/decompiler/fernflower/FernFlowerResultSaver.java#L46-L64